### PR TITLE
Add WhatsApp GPT-4 bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+baileys_auth/
+.env
+
+package-lock.json

--- a/bot/handlers/gptHandler.js
+++ b/bot/handlers/gptHandler.js
@@ -1,0 +1,21 @@
+const { OpenAI } = require('openai');
+require('dotenv').config();
+
+const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+});
+
+async function handleGPT(prompt) {
+    try {
+        const completion = await openai.chat.completions.create({
+            model: 'gpt-4',
+            messages: [{ role: 'user', content: prompt }],
+        });
+        return completion.choices[0].message.content.trim();
+    } catch (error) {
+        console.error('OpenAI error:', error);
+        return 'Sorry, I could not process that.';
+    }
+}
+
+module.exports = { handleGPT };

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,0 +1,31 @@
+const baileys = require('baileys');
+const { useMultiFileAuthState } = baileys;
+const { handleGPT } = require('./handlers/gptHandler');
+require('dotenv').config();
+
+async function startBot() {
+    const { state, saveCreds } = await useMultiFileAuthState('baileys_auth');
+    const sock = baileys.default({
+        printQRInTerminal: true,
+        auth: state,
+    });
+
+    sock.ev.on('creds.update', saveCreds);
+
+    sock.ev.on('messages.upsert', async ({ messages }) => {
+        const msg = messages[0];
+        if (!msg.message || msg.key.fromMe) return;
+
+        const body = msg.message.conversation ||
+            msg.message.extendedTextMessage?.text || '';
+
+        if (body.startsWith('!gpt')) {
+            const prompt = body.replace('!gpt', '').trim();
+            const response = await handleGPT(prompt);
+            await sock.sendMessage(msg.key.remoteJid, { text: response }, { quoted: msg });
+        }
+    });
+}
+
+startBot();
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": {
+    "baileys": "^6.7.18",
+    "body-parser": "^2.2.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.5.0",
+    "exceljs": "^4.4.0",
+    "express": "^5.1.0",
+    "fluent-ffmpeg": "^2.1.3",
+    "google-tts-api": "^2.0.2",
+    "mongodb": "^6.17.0",
+    "mongoose": "^8.15.1",
+    "openai": "^5.1.1",
+    "pdfkit": "^0.17.1"
+  },
+  "scripts": {
+    "start": "node bot/index.js"
+  }
+}


### PR DESCRIPTION
## Summary
- implement WhatsApp bot using Baileys and OpenAI
- reply to `!gpt` commands with GPT‑4 answers
- load environment variables with dotenv
- ignore runtime artifacts and node modules
- add `npm start` script for running the bot

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68436280332c83209da5be090cdaf6a1