### PR TITLE
Handle QR via connection.update

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -1,13 +1,24 @@
 const baileys = require('baileys');
 const { useMultiFileAuthState } = baileys;
+const qrcode = require('qrcode-terminal');
 const { handleGPT } = require('./handlers/gptHandler');
 require('dotenv').config();
 
 async function startBot() {
     const { state, saveCreds } = await useMultiFileAuthState('baileys_auth');
     const sock = baileys.default({
-        printQRInTerminal: true,
         auth: state,
+    });
+
+    sock.ev.on('connection.update', ({ connection, qr }) => {
+        if (qr) {
+            qrcode.generate(qr, { small: true });
+        }
+        if (connection === 'open') {
+            console.log('Connection opened');
+        } else if (connection === 'close') {
+            console.log('Connection closed');
+        }
     });
 
     sock.ev.on('creds.update', saveCreds);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "mongodb": "^6.17.0",
     "mongoose": "^8.15.1",
     "openai": "^5.1.1",
-    "pdfkit": "^0.17.1"
+    "pdfkit": "^0.17.1",
+    "qrcode-terminal": "^0.12.0"
   },
   "scripts": {
     "start": "node bot/index.js"


### PR DESCRIPTION
## Summary
- remove deprecated `printQRInTerminal`
- display QR in terminal using qrcode-terminal
- log connection open/close
- add qrcode-terminal to dependencies

## Testing
- `npm test` *(fails: Missing script)*
- `node --check bot/index.js`


------
https://chatgpt.com/codex/tasks/task_e_684368518f5c83208f124f0f34635608