### PR TITLE
Improve mention detection and scheduling

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -64,7 +64,17 @@ async function startSock() {
 
   sock.ev.on('messages.upsert', async ({ messages }) => {
     const m = messages[0];
-    await handleMessage(sock, m);
+    try {
+      await handleMessage(sock, m);
+    } catch (err) {
+      if (/decrypt/i.test(err.message)) {
+        console.warn('[Session]', 'Decryption failed, restarting session...');
+        try { await sock.logout(); } catch (_) {}
+        startSock();
+      } else {
+        console.error('Message error:', err);
+      }
+    }
   });
 
   sock.ev.on('messages.reaction', async (reactions) => {


### PR DESCRIPTION
## Summary
- handle mentions in groups more reliably with custom name and jid matching
- sanitize scheduled reminder text and reply with confirmation
- auto-recover on decrypt errors
- add detailed mention logging

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843df56147483208c54ce5c42652fe0