### PR TITLE
Implement open-wa message handler with scheduler

### DIFF
--- a/bot/handlers/memoryHandler.js
+++ b/bot/handlers/memoryHandler.js
@@ -14,14 +14,26 @@ async function getRecentMessages(userId, limit = 200) {
   return Memory.find({ userId }).sort({ timestamp: -1 }).limit(limit).lean();
 }
 
-async function saveInteraction(chatId, m, response) {
-  const text =
-    m.message.conversation ||
-    m.message.extendedTextMessage?.text ||
-    m.message.imageMessage?.caption ||
-    m.message.videoMessage?.caption ||
-    '';
-  await Memory.create({ chatId, userId: m.key.participant || m.key.remoteJid, text, response });
+function extractText(m) {
+  if (!m) return '';
+  if (m.body) return m.body;
+  if (m.text) return m.text;
+  if (m.caption) return m.caption;
+  if (m.message)
+    return (
+      m.message.conversation ||
+      m.message.extendedTextMessage?.text ||
+      m.message.imageMessage?.caption ||
+      m.message.videoMessage?.caption ||
+      ''
+    );
+  return '';
 }
 
-module.exports = { saveInteraction, getRecentMessages, Memory };
+async function saveInteraction(chatId, m, response) {
+  const text = extractText(m);
+  const userId = m.sender?.id || m.key?.participant || m.key?.remoteJid;
+  await Memory.create({ chatId, userId, text, response });
+}
+
+module.exports = { saveInteraction, getRecentMessages, Memory, extractText };

--- a/bot/handlers/openwaMessageHandler.js
+++ b/bot/handlers/openwaMessageHandler.js
@@ -1,0 +1,72 @@
+const { askGPT } = require('../../utils/gpt');
+const memoryHandler = require('./memoryHandler');
+const { getOrCreateMemory, setBotName, addFact, updateSummary } = require('../../utils/memory');
+const { addJob } = require('../../utils/scheduler');
+const chrono = require('chrono-node');
+
+/**
+ * Handle an incoming message from @open-wa/wa-automate.
+ * @param {*} client The wa-automate client
+ * @param {*} message The incoming message
+ * @param {string} botId The bot's jid (e.g. 12345@c.us)
+ * @param {string} defaultName The default name of the bot
+ */
+async function handleOpenWaMessage(client, message, botId, defaultName = 'zaphar') {
+  const text = message.body || message.caption || '';
+  if (!text || message.fromMe) return;
+
+  const from = message.chatId;
+  const isGroup = message.isGroupMsg;
+  const userId = isGroup ? message.sender.id : from;
+  const userMem = await getOrCreateMemory(userId);
+  const botName = (userMem.name || defaultName).toLowerCase();
+
+  const mentionByJid = (message.mentionedJidList || []).includes(botId);
+  const mentionByName = new RegExp(`@${botName}\\b`, 'i').test(text);
+  const isReplyToBot = message.quotedMsg && message.quotedMsg.fromMe;
+
+  const shouldReply = !isGroup || mentionByJid || isReplyToBot || mentionByName;
+  if (!shouldReply) return;
+
+  console.log('[MSG]', { from, isGroup, mentionByJid, mentionByName, isReplyToBot });
+
+  let prompt = text.replace(/@[0-9]+/g, '').replace(new RegExp(`@${botName}\\b`, 'ig'), '').trim();
+
+  const nameSet = prompt.match(/your name is now\s+(.+)/i);
+  if (nameSet) {
+    await setBotName(userId, nameSet[1]);
+    await client.reply(from, `Okay, I'll go by ${nameSet[1].trim()} now!`, message.id);
+    return;
+  }
+
+  if (/podcast/i.test(prompt)) {
+    await addFact(userId, 'podcast', true);
+  }
+
+  if (/(send|remind)/i.test(prompt)) {
+    const parsed = chrono.parse(prompt, new Date(), { forwardDate: true });
+    if (parsed.length) {
+      const { start, text: timeText } = parsed[0];
+      const date = start.date();
+      let msg = prompt
+        .replace(timeText, '')
+        .replace(/^(send|remind)( me)?( to)?/i, '')
+        .trim();
+      await addJob(from, msg, date);
+      await client.reply(from, `Got it! I'll remind you at ${date.toLocaleString()} to: ${msg}`, message.id);
+      return;
+    }
+  }
+
+  try {
+    const reply = await askGPT(prompt, userMem, message.sender.pushname);
+    await client.reply(from, reply, message.id);
+    await memoryHandler.saveInteraction(from, message, reply);
+    await updateSummary(userId);
+  } catch (err) {
+    console.error('[MSG ERR]', err);
+    await client.reply(from, '⚠️ Something went wrong.', message.id);
+  }
+}
+
+module.exports = { handleOpenWaMessage };

--- a/bot/openwa.js
+++ b/bot/openwa.js
@@ -1,0 +1,39 @@
+const { create } = require('@open-wa/wa-automate');
+const mongoose = require('mongoose');
+const path = require('path');
+const fs = require('fs');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
+const { handleOpenWaMessage } = require('./handlers/openwaMessageHandler');
+const { startScheduler } = require('../utils/scheduler');
+
+async function start() {
+  const mongoUri = process.env.MONGODB_URI;
+  if (!mongoUri) {
+    throw new Error('MONGODB_URI is not defined in .env');
+  }
+  await mongoose.connect(mongoUri, {});
+  console.log('MongoDB Connected');
+
+  const client = await create({
+    sessionId: 'zaphar',
+    multiDevice: true,
+    authTimeout: 60,
+    headless: true,
+  });
+
+  const botNumber = await client.getHostNumber();
+  const botId = `${botNumber}@c.us`;
+
+  startScheduler((chatId, text) => client.sendText(chatId, text));
+
+  client.onMessage(async (message) => {
+    try {
+      await handleOpenWaMessage(client, message, botId);
+    } catch (err) {
+      console.error('[onMessage]', err);
+    }
+  });
+}
+
+start().catch((err) => console.error('Startup error:', err));

--- a/models/ScheduledMessage.js
+++ b/models/ScheduledMessage.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 
 const scheduledMessageSchema = new mongoose.Schema({
-  userId: String,
+  chatId: String,
   message: String,
   scheduledTime: Date,
   sent: { type: Boolean, default: false },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@whiskeysockets/baileys": "^6.7.18",
     "axios": "^1.9.0",
     "body-parser": "^2.2.0",
+    "chrono-node": "^2.8.2",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "exceljs": "^4.4.0",
@@ -17,10 +18,10 @@
     "openai": "^5.1.1",
     "pdfkit": "^0.17.1",
     "qrcode-terminal": "^0.12.0",
-    "which": "^5.0.0",
-    "chrono-node": "^2.8.2"
+    "which": "^5.0.0"
   },
   "scripts": {
-    "start": "node bot/index.js"
+    "start": "node bot/index.js",
+    "start-openwa": "node bot/openwa.js"
   }
 }


### PR DESCRIPTION
## Summary
- add open-wa entry script
- create handler for @open-wa/wa-automate messages
- extend memory handler to support both message formats
- rename scheduled message field to `chatId`
- check scheduler every 10 seconds
- add npm script to run the open-wa version

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843e4ffc71c83208d1c243105df94ab