### PR TITLE
Implement group setup and GPT scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# OpenWA AI Bot
+
+This bot uses OpenWA and Baileys to provide GPT powered replies in WhatsApp chats.
+
+## Group Setup
+
+When the bot joins a group it checks whether each participant has messaged the bot privately. If not, they will receive a direct message asking them to say hi. Until each member replies, the bot will post a reminder in the group:
+
+```
+Not all group members have completed bot setup. Please reply to my DM to enable group features.
+```
+
+Group admins should ensure everyone responds so the bot can mention them and handle replies correctly.
+
+## Headless Mode
+
+The bot runs in headless mode by default. Set `HEADLESS=false` in the environment to launch a visible browser for debugging.

--- a/bot/handlers/groupInit.js
+++ b/bot/handlers/groupInit.js
@@ -1,0 +1,39 @@
+const { Memory } = require('./memoryHandler');
+const { getOrCreateMemory, addFact } = require('../../utils/memory');
+
+async function ensureMemberSession(client, memberId, groupId, botId) {
+  if (memberId === botId) return true;
+  const hasDm = await Memory.exists({ userId: memberId, chatId: memberId });
+  const userMem = await getOrCreateMemory(memberId);
+  const flagKey = `setupPrompted_${groupId}`;
+  const prompted = userMem.memory && userMem.memory[flagKey];
+  if (!hasDm && !prompted) {
+    await client.sendText(
+      memberId,
+      'Hey, I need a quick reply here to finish setup for group chat features! Please say hi.'
+    );
+    await addFact(memberId, flagKey, true);
+  }
+  return hasDm;
+}
+
+async function processGroup(client, groupId, botId) {
+  try {
+    const members = await client.getGroupMembersId(groupId);
+    let missing = [];
+    for (const id of members) {
+      const ok = await ensureMemberSession(client, id, groupId, botId);
+      if (!ok) missing.push(id);
+    }
+    if (missing.length) {
+      await client.sendText(
+        groupId,
+        'Not all group members have completed bot setup. Please reply to my DM to enable group features.'
+      );
+    }
+  } catch (err) {
+    console.error('[GROUP INIT]', err.message);
+  }
+}
+
+module.exports = { processGroup };

--- a/bot/handlers/messageHandler.js
+++ b/bot/handlers/messageHandler.js
@@ -91,7 +91,7 @@ async function handleMessage(sock, m) {
           return;
         }
 
-        await addJob(from, msg, date);
+        await addJob(from, msg, date, userId);
         await sock.sendMessage(from, { text: `Got it ${m.pushName}, I’ll remind you at ${date.toLocaleString()} to: ${msg}` }, { quoted: m });
         return;
       }

--- a/bot/handlers/openwaMessageHandler.js
+++ b/bot/handlers/openwaMessageHandler.js
@@ -30,7 +30,10 @@ async function handleOpenWaMessage(client, message, botId, defaultName = 'zaphar
   const botName = (userMem.name || defaultName).toLowerCase();
 
   const mentionByJid = (message.mentionedJidList || []).includes(botId);
-  const isReplyToBot = message.quotedMsg && message.quotedMsg.fromMe;
+  const isReplyToBot =
+    (message.quotedMsg && message.quotedMsg.fromMe) ||
+    (message.quotedMsgObj && message.quotedMsgObj.fromMe) ||
+    message.quotedParticipant === botId;
 
   const shouldReply = !isGroup || mentionByJid || isReplyToBot;
   if (!shouldReply) return;
@@ -67,7 +70,7 @@ async function handleOpenWaMessage(client, message, botId, defaultName = 'zaphar
         return;
       }
 
-      await addJob(from, msg, date);
+      await addJob(from, msg, date, userId);
       await client.reply(
         from,
         `Got it ${message.sender.pushname}, I'll remind you at ${date.toLocaleString()} to: ${msg}`,

--- a/models/ScheduledMessage.js
+++ b/models/ScheduledMessage.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 
 const scheduledMessageSchema = new mongoose.Schema({
   chatId: String,
+  prompt: String,
+  userId: String,
   message: String,
   scheduledTime: Date,
   sent: { type: Boolean, default: false },


### PR DESCRIPTION
## Summary
- create README with group setup notes
- implement group session initialization logic
- warn about headless mode in startup
- improve mention detection for OpenWA
- schedule prompts and generate replies with GPT

## Testing
- `npm --version`
- `node -v`
- `node bot/openwa.js` *(fails: MONGODB_URI not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68447d19db50832080789c664228c06a