### PR TITLE
Add Express API routes with CORS and integrate into bot

### DIFF
--- a/bot/openwa.js
+++ b/bot/openwa.js
@@ -2,7 +2,21 @@ const { create } = require('@open-wa/wa-automate');
 const mongoose = require('mongoose');
 const path = require('path');
 const fs = require('fs');
+const express = require('express');
+const cors = require('cors');
+const apiRoutes = require('../routes/api');
 require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
+// ---- Express API Setup ----
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use('/api', apiRoutes);
+
+const PORT = process.env.API_PORT || 3001;
+app.listen(PORT, () => console.log(`[API] Listening on port ${PORT}`));
+
+// TODO: Expose real data from the bot inside routes/api.js
 
 const { handleOpenWaMessage } = require('./handlers/openwaMessageHandler');
 const { startScheduler } = require('../utils/scheduler');

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+
+// API routes providing bot statistics and actions.
+// These return stub data for now; integrate with the WhatsApp bot to
+// supply real metrics when available.
+
+// TODO: Replace stub data with real bot metrics
+router.get('/status', (req, res) => {
+  res.json({ online: true, uptime: '12h 15m', activeGroups: 3 });
+});
+
+router.get('/messages/today', (req, res) => {
+  res.json({ count: 128 });
+});
+
+router.get('/users/active', (req, res) => {
+  res.json({ count: 24 });
+});
+
+router.get('/activity', (req, res) => {
+  // Example array of 10 recent events
+  const events = Array.from({ length: 10 }).map((_, idx) => ({
+    type: 'message',
+    user: `user${idx + 1}`,
+    message: `Test message ${idx + 1}`,
+    timestamp: Date.now() - idx * 60000,
+  }));
+  res.json(events);
+});
+
+router.post('/bot/restart', (req, res) => {
+  console.log('Bot restart requested');
+  // TODO: hook into actual bot restart logic
+  res.json({ ok: true });
+});
+
+module.exports = router;
+


### PR DESCRIPTION
## Summary
- implement new Express API routes under `routes/api.js`
- set up Express with CORS in `bot/openwa.js` and mount API at `/api`
- include TODOs and comments for future integration with bot data

## Testing
- `node -c bot/openwa.js`
- `node -c routes/api.js`
- `npm run | head`

------
https://chatgpt.com/codex/tasks/task_e_684498d6a6b0832095394e74d55797ff