### PR TITLE
Implement JWT authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# MongoDB connection
+MONGODB_URI=mongodb://localhost:27017/yourdb
+
+# API port
+API_PORT=3001
+
+# Whether the bot should run headless
+HEADLESS=true
+
+# OpenAI API key
+OPENAI_API_KEY=your-openai-key
+
+# JWT settings
+JWT_SECRET=change-this-secret
+JWT_EXPIRES_IN=1d

--- a/README.md
+++ b/README.md
@@ -9,3 +9,71 @@ When the bot joins a group it checks whether each participant has messaged the b
 ## Headless Mode
 
 The bot runs in headless mode by default. Set `HEADLESS=false` in the environment to launch a visible browser for debugging.
+
+## Authentication API
+
+The API exposes JWT based authentication endpoints under `/api/auth`.
+
+### Register
+
+```http
+POST /api/auth/register
+```
+
+Body:
+
+```json
+{
+  "email": "user@example.com",
+  "password": "secret",
+  "displayName": "Test User"
+}
+```
+
+Response:
+
+```json
+{
+  "token": "<jwt>",
+  "user": { "email": "user@example.com", "displayName": "Test User", "role": "user" }
+}
+```
+
+### Login
+
+```http
+POST /api/auth/login
+```
+
+Body:
+
+```json
+{
+  "email": "user@example.com",
+  "password": "secret"
+}
+```
+
+Returns the same shape as registration. Store the token on the frontend (e.g. `localStorage`) and send it in the `Authorization` header as `Bearer <token>` for protected routes.
+
+The server validates the JWT on each request and attaches the user to `req.user` when valid.
+
+### Current User
+
+```http
+GET /api/auth/me
+```
+
+Requires the `Authorization` header and returns the logged in user's information.
+
+Use tools like Postman to test these endpoints by sending JSON bodies and setting the `Authorization` header when needed.
+
+TODO: add password reset and email verification flows.
+
+To protect your own routes, import `auth` from `middleware/auth` and pass it as middleware:
+
+```js
+const auth = require('../middleware/auth');
+router.get('/my-protected', auth, (req, res) => { ... });
+```
+For admin-only routes use `isAdmin` in addition to `auth`.

--- a/bot/openwa.js
+++ b/bot/openwa.js
@@ -5,12 +5,14 @@ const fs = require('fs');
 const express = require('express');
 const cors = require('cors');
 const apiRoutes = require('../routes/api');
+const authRoutes = require('../routes/auth');
 require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
 // ---- Express API Setup ----
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.use('/api/auth', authRoutes);
 app.use('/api', apiRoutes);
 
 const PORT = process.env.API_PORT || 3001;

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+module.exports = async function auth(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  const token = authHeader.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await User.findById(payload.id).select('-password');
+    if (!user) return res.status(401).json({ message: 'Unauthorized' });
+    req.user = user;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+};

--- a/middleware/isAdmin.js
+++ b/middleware/isAdmin.js
@@ -1,0 +1,6 @@
+module.exports = function isAdmin(req, res, next) {
+  if (!req.user || req.user.role !== 'admin') {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+  next();
+};

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true, lowercase: true, trim: true },
+  password: { type: String, required: true },
+  displayName: { type: String },
+  avatarUrl: { type: String },
+  role: { type: String, enum: ['user', 'admin'], default: 'user' },
+});
+
+// Hash password before saving
+userSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  try {
+    const salt = await bcrypt.genSalt(10);
+    this.password = await bcrypt.hash(this.password, salt);
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+userSchema.methods.comparePassword = function (candidate) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+module.exports = mongoose.model('User', userSchema);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "openai": "^5.1.1",
     "pdfkit": "^0.17.1",
     "qrcode-terminal": "^0.12.0",
-    "which": "^5.0.0"
+    "which": "^5.0.0",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.2"
   },
   "scripts": {
     "start": "node bot/openwa.js"

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,4 +1,6 @@
 const express = require('express');
+const auth = require('../middleware/auth');
+const isAdmin = require('../middleware/isAdmin');
 const router = express.Router();
 
 // API routes providing bot statistics and actions.
@@ -6,7 +8,7 @@ const router = express.Router();
 // supply real metrics when available.
 
 // TODO: Replace stub data with real bot metrics
-router.get('/status', (req, res) => {
+router.get('/status', auth, (req, res) => {
   res.json({ online: true, uptime: '12h 15m', activeGroups: 3 });
 });
 
@@ -16,6 +18,11 @@ router.get('/messages/today', (req, res) => {
 
 router.get('/users/active', (req, res) => {
   res.json({ count: 24 });
+});
+
+// Example protected route
+router.get('/protected', auth, (req, res) => {
+  res.json({ message: `Hello ${req.user.displayName || req.user.email}` });
 });
 
 router.get('/activity', (req, res) => {
@@ -29,7 +36,7 @@ router.get('/activity', (req, res) => {
   res.json(events);
 });
 
-router.post('/bot/restart', (req, res) => {
+router.post('/bot/restart', auth, isAdmin, (req, res) => {
   console.log('Bot restart requested');
   // TODO: hook into actual bot restart logic
   res.json({ ok: true });

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,72 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+// TODO: add email verification and password reset routes
+
+function generateToken(user) {
+  const payload = { id: user._id };
+  const expiresIn = process.env.JWT_EXPIRES_IN || '1d';
+  const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn });
+  return token;
+}
+
+router.post('/register', async (req, res) => {
+  try {
+    const { email, password, displayName, avatarUrl } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Email and password are required' });
+    }
+    const existing = await User.findOne({ email });
+    if (existing) {
+      return res.status(409).json({ message: 'Email already in use' });
+    }
+    const user = await User.create({ email, password, displayName, avatarUrl });
+    const token = generateToken(user);
+    const userData = user.toObject();
+    delete userData.password;
+    res.status(201).json({ token, user: userData });
+  } catch (err) {
+    res.status(500).json({ message: 'Registration failed' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Email and password are required' });
+    }
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const match = await user.comparePassword(password);
+    if (!match) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const token = generateToken(user);
+    const userData = user.toObject();
+    delete userData.password;
+    res.json({ token, user: userData });
+  } catch (err) {
+    res.status(500).json({ message: 'Login failed' });
+  }
+});
+
+router.post('/logout', (req, res) => {
+  // For stateless JWT, logout is handled client-side
+  // TODO: Implement token blacklist for proper logout if needed
+  res.json({ message: 'Logged out' });
+});
+
+router.get('/me', auth, (req, res) => {
+  res.json({ user: req.user });
+});
+
+// Additional routes can be added here, e.g. password reset
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add user model for MongoDB
- add auth and admin middleware
- implement `/api/auth` routes for register/login/logout/me
- secure API routes with JWT and example protected endpoints
- expose auth routes from Express server
- document new API endpoints and usage
- provide `.env.example` with auth settings

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845ced2bdd8832094491f8a2ce08a21