### PR TITLE
Add JWT auth to frontend

### DIFF
--- a/zaphchat-frontend/App.tsx
+++ b/zaphchat-frontend/App.tsx
@@ -4,6 +4,8 @@ import Sidebar from './components/Sidebar';
 import MainContent from './components/MainContent';
 import AnimatedBackground from './components/AnimatedBackground';
 import Header from './components/Header';
+import LoginPage from './components/pages/LoginPage';
+import { useAuth } from './AuthContext';
 import { NavItemConfig } from './types';
 import { LayoutDashboardIcon, BarChart2Icon, CalendarClockIcon, Users2Icon, RobotIcon, FileTextIcon, SettingsIcon as GeneralSettingsIcon } from './components/icons'; // Renamed SettingsIcon to avoid conflict
 
@@ -21,6 +23,7 @@ const LG_BREAKPOINT = '(min-width: 1024px)';
 export type ServerStatusType = 'operational' | 'rebooting' | 'down';
 
 const App: React.FC = () => {
+  const { token, logout } = useAuth();
   const [isSidebarOpen, setIsSidebarOpen] = useState(window.matchMedia(LG_BREAKPOINT).matches);
   const [activePageId, setActivePageId] = useState<string>(navigationConfig[0].id);
   const [pageTitle, setPageTitle] = useState<string>(navigationConfig[0].name);
@@ -75,16 +78,20 @@ const App: React.FC = () => {
     }
   }, [activePageId]);
 
+  if (!token) {
+    return <LoginPage />;
+  }
 
   return (
     <div className="relative h-screen flex flex-col bg-slate-900 overflow-hidden">
       <AnimatedBackground />
-      <Header 
-        appName="ZaphChat" 
+      <Header
+        appName="ZaphChat"
         pageTitle={pageTitle}
         isSidebarOpen={isSidebarOpen}
-        toggleSidebar={toggleSidebar} 
+        toggleSidebar={toggleSidebar}
         serverStatus={serverStatus}
+        onLogout={logout}
       />
       <div className="flex flex-1 overflow-hidden relative"> {/* Added relative for absolute positioning of Sidebar */}
         <Sidebar 

--- a/zaphchat-frontend/AuthContext.tsx
+++ b/zaphchat-frontend/AuthContext.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { API_BASE_URL } from './api';
+
+interface AuthContextProps {
+  token: string | null;
+  user: any | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined);
+
+export const AuthProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('token');
+    }
+    return null;
+  });
+  const [user, setUser] = useState<any | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    localStorage.setItem('token', token);
+    if (!user) {
+      fetch(`${API_BASE_URL}/auth/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then(res => res.ok ? res.json() : Promise.reject())
+        .then(data => setUser(data.user))
+        .catch(() => {
+          setToken(null);
+          setUser(null);
+          localStorage.removeItem('token');
+        });
+    }
+  }, [token]);
+
+  const login = async (email: string, password: string) => {
+    const res = await fetch(`${API_BASE_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.message || 'Login failed');
+    }
+    setToken(data.token);
+    setUser(data.user);
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('token');
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};

--- a/zaphchat-frontend/api.ts
+++ b/zaphchat-frontend/api.ts
@@ -1,7 +1,12 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
 
-export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE_URL}${path}`, options);
+export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const headers = new Headers(options.headers || {});
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
   if (!res.ok) {
     throw new Error(`API request failed with status ${res.status}`);
   }

--- a/zaphchat-frontend/components/Header.tsx
+++ b/zaphchat-frontend/components/Header.tsx
@@ -9,9 +9,10 @@ interface HeaderProps {
   isSidebarOpen: boolean;
   toggleSidebar: () => void;
   serverStatus: ServerStatusType; // Added serverStatus prop
+  onLogout: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ appName, pageTitle, isSidebarOpen, toggleSidebar, serverStatus }) => {
+const Header: React.FC<HeaderProps> = ({ appName, pageTitle, isSidebarOpen, toggleSidebar, serverStatus, onLogout }) => {
   
   const getServerStatusIndicator = () => {
     let iconColor = 'text-slate-500'; // Default
@@ -91,6 +92,12 @@ const Header: React.FC<HeaderProps> = ({ appName, pageTitle, isSidebarOpen, togg
           </div> 
           */}
         </div>
+        <button
+          onClick={onLogout}
+          className="px-3 py-2 rounded-xl bg-slate-700/70 hover:bg-slate-600/70 text-slate-200 text-sm"
+        >
+          Log Out
+        </button>
       </div>
     </header>
   );

--- a/zaphchat-frontend/components/pages/LoginPage.tsx
+++ b/zaphchat-frontend/components/pages/LoginPage.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import GlassCard from '../GlassCard';
+import PremiumButton from '../PremiumButton';
+import { useAuth } from '../../AuthContext';
+
+const LoginPage: React.FC = () => {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      await login(email, password);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4 bg-slate-900">
+      <GlassCard className="w-full max-w-md">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <h2 className="text-2xl font-semibold text-slate-100 text-center mb-4">Login to ZaphChat</h2>
+          {error && <p className="text-red-500 text-sm text-center">{error}</p>}
+          <div>
+            <label className="block text-sm font-medium text-slate-200 mb-1">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="w-full bg-slate-700/60 border border-slate-600/80 rounded-lg px-3 py-2 text-slate-100 focus:ring-cyan-500 focus:border-cyan-500"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-200 mb-1">Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              className="w-full bg-slate-700/60 border border-slate-600/80 rounded-lg px-3 py-2 text-slate-100 focus:ring-cyan-500 focus:border-cyan-500"
+              required
+            />
+          </div>
+          <div className="pt-2 text-center">
+            <PremiumButton type="submit" disabled={loading}>
+              {loading ? 'Signing in...' : 'Sign In'}
+            </PremiumButton>
+          </div>
+        </form>
+      </GlassCard>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/zaphchat-frontend/index.tsx
+++ b/zaphchat-frontend/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { AuthProvider } from './AuthContext';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +12,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- implement `AuthContext` for login state and token storage
- create a glassmorphic `LoginPage`
- update `App` to gate pages behind authentication
- add logout button to the header
- include JWT in API requests and export API base
- wrap the app with `AuthProvider`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845da41bd948320bd0ad9a2a7fb3342