### PR TITLE
Fix register API response and client flow

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -19,27 +19,40 @@ router.post('/register', async (req, res) => {
   try {
     const { email, password, name } = req.body;
     if (!email || !password || !name) {
-      return res.status(400).json({ message: 'Name, email and password are required' });
+      return res
+        .status(400)
+        .json({ success: false, message: 'Name, email and password are required' });
     }
     if (!validator.isEmail(email)) {
-      return res.status(400).json({ message: 'Invalid email format' });
+      return res
+        .status(400)
+        .json({ success: false, message: 'Invalid email format' });
     }
-    if (!validator.isStrongPassword(password, { minLength: 6 })) {
-      return res.status(400).json({ message: 'Password is too weak' });
+    if (password.length < 8) {
+      return res
+        .status(400)
+        .json({ success: false, message: 'Password must be at least 8 characters' });
     }
 
     const existing = await User.findOne({ email });
     if (existing) {
-      return res.status(409).json({ message: 'Email already in use' });
+      return res
+        .status(409)
+        .json({ success: false, message: 'That email is already in use' });
     }
 
     const user = await User.create({ email, password, displayName: name });
-    const token = generateToken(user);
-    const userData = user.toObject();
-    delete userData.password;
-    res.status(201).json({ token, user: userData });
+    const userData = {
+      email: user.email,
+      displayName: user.displayName,
+      role: user.role,
+    };
+    res
+      .status(201)
+      .json({ success: true, message: 'User registered successfully', user: userData });
   } catch (err) {
-    res.status(500).json({ message: 'Registration failed' });
+    console.error(err);
+    res.status(500).json({ success: false, message: 'Registration failed' });
   }
 });
 

--- a/zaphchat-frontend/AuthContext.tsx
+++ b/zaphchat-frontend/AuthContext.tsx
@@ -5,7 +5,11 @@ interface AuthContextProps {
   token: string | null;
   user: any | null;
   login: (email: string, password: string) => Promise<void>;
-  register: (name: string, email: string, password: string) => Promise<void>;
+  register: (
+    name: string,
+    email: string,
+    password: string
+  ) => Promise<{ success: boolean; message: string; user?: any }>;
   logout: () => void;
 }
 
@@ -61,8 +65,7 @@ export const AuthProvider: React.FC<{children: React.ReactNode}> = ({ children }
     if (!res.ok) {
       throw new Error(data.message || 'Registration failed');
     }
-    setToken(data.token);
-    setUser(data.user);
+    return data;
   };
 
   const logout = () => {

--- a/zaphchat-frontend/components/pages/RegisterPage.tsx
+++ b/zaphchat-frontend/components/pages/RegisterPage.tsx
@@ -21,10 +21,18 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ onShowLogin, onRegistered }
       setError('Passwords do not match');
       return;
     }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
     setLoading(true);
     try {
-      await register(name, email, password);
-      onRegistered && onRegistered(name);
+      const data = await register(name, email, password);
+      if (data.success) {
+        onRegistered && onRegistered(name);
+      } else {
+        setError(data.message || 'Registration failed');
+      }
     } catch (err: any) {
       setError(err.message);
     } finally {


### PR DESCRIPTION
## Summary
- clean up register endpoint to send success boolean and better error messages
- expose password length validation
- update auth context register call to return backend response
- show backend message in registration form and validate password length

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845e84ebfc0832083194d45206b08db