### PR TITLE
Fix login route and show server errors

### DIFF
--- a/zaphchat-frontend/AuthContext.tsx
+++ b/zaphchat-frontend/AuthContext.tsx
@@ -48,11 +48,14 @@ export const AuthProvider: React.FC<{children: React.ReactNode}> = ({ children }
       body: JSON.stringify({ email, password }),
     });
     const data = await res.json().catch(() => ({}));
-    if (!res.ok) {
+    if (!res.ok || data.success === false) {
       throw new Error(data.message || 'Login failed');
     }
     setToken(data.token);
     setUser(data.user);
+    if (typeof window !== 'undefined') {
+      window.location.href = '/';
+    }
   };
 
   const register = async (name: string, email: string, password: string) => {


### PR DESCRIPTION
## Summary
- tweak `/api/auth/login` backend route
  - handle missing fields
  - check JWT_SECRET
  - log errors
  - send consistent success/false responses
- improve AuthContext login function to display server message and redirect

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845ed0415d883209e12dda771993514