### PR TITLE
Implement bot management backend and frontend

### DIFF
--- a/bot/openwa.js
+++ b/bot/openwa.js
@@ -6,6 +6,7 @@ const express = require('express');
 const cors = require('cors');
 const apiRoutes = require('../routes/api');
 const authRoutes = require('../routes/auth');
+const botRoutes = require('../routes/bots');
 require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
 // ---- Express API Setup ----
@@ -14,6 +15,7 @@ app.use(cors());
 app.use(express.json());
 app.use('/api/auth', authRoutes);
 app.use('/api', apiRoutes);
+app.use('/api/bots', botRoutes);
 
 const PORT = process.env.API_PORT || 3001;
 app.listen(PORT, () => console.log(`[API] Listening on port ${PORT}`));

--- a/models/Bot.js
+++ b/models/Bot.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const contactSchema = new mongoose.Schema({
+  name: String,
+  phoneNumber: String,
+}, { _id: false });
+
+const botSchema = new mongoose.Schema({
+  owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  botName: { type: String, required: true },
+  phoneNumber: String,
+  whatsappId: String,
+  status: { type: String, enum: ['online', 'paused', 'archived'], default: 'online' },
+  personality: String,
+  contacts: [contactSchema],
+  conversations: { type: [mongoose.Schema.Types.Mixed], default: [] },
+  messages: { type: [mongoose.Schema.Types.Mixed], default: [] },
+}, { timestamps: true });
+
+module.exports = mongoose.model('Bot', botSchema);

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const auth = require('../middleware/auth');
 const isAdmin = require('../middleware/isAdmin');
+const Bot = require('../models/Bot');
+const ScheduledMessage = require('../models/ScheduledMessage');
 const router = express.Router();
 
 // API routes providing bot statistics and actions.
@@ -8,16 +10,25 @@ const router = express.Router();
 // supply real metrics when available.
 
 // TODO: Replace stub data with real bot metrics
+router.get('/ping', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
 router.get('/status', auth, (req, res) => {
-  res.json({ online: true, uptime: '12h 15m', activeGroups: 3 });
+  res.json({ online: true });
 });
 
-router.get('/messages/today', (req, res) => {
-  res.json({ count: 128 });
+router.get('/stats/messages', auth, async (req, res) => {
+  const bots = await Bot.find({ owner: req.user._id });
+  const count = bots.reduce((n, b) => n + (b.messages?.length || 0), 0);
+  res.json({ count });
 });
 
-router.get('/users/active', (req, res) => {
-  res.json({ count: 24 });
+router.get('/stats/active-users', auth, async (req, res) => {
+  const bots = await Bot.find({ owner: req.user._id });
+  const contacts = new Set();
+  bots.forEach(b => b.contacts.forEach(c => contacts.add(c.phoneNumber)));
+  res.json({ count: contacts.size });
 });
 
 // Example protected route
@@ -25,21 +36,27 @@ router.get('/protected', auth, (req, res) => {
   res.json({ message: `Hello ${req.user.displayName || req.user.email}` });
 });
 
-router.get('/activity', (req, res) => {
-  // Example array of 10 recent events
-  const events = Array.from({ length: 10 }).map((_, idx) => ({
-    type: 'message',
-    user: `user${idx + 1}`,
-    message: `Test message ${idx + 1}`,
-    timestamp: Date.now() - idx * 60000,
-  }));
-  res.json(events);
+router.get('/activity/recent', auth, async (req, res) => {
+  const bots = await Bot.find({ owner: req.user._id });
+  let messages = [];
+  bots.forEach(b => {
+    if (Array.isArray(b.messages)) {
+      messages = messages.concat(b.messages);
+    }
+  });
+  messages.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+  res.json(messages.slice(0, 10));
 });
 
 router.post('/bot/restart', auth, isAdmin, (req, res) => {
   console.log('Bot restart requested');
   // TODO: hook into actual bot restart logic
   res.json({ ok: true });
+});
+
+router.get('/scheduler/tasks', auth, async (req, res) => {
+  const tasks = await ScheduledMessage.find({ sent: false });
+  res.json(tasks);
 });
 
 module.exports = router;

--- a/routes/bots.js
+++ b/routes/bots.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const Bot = require('../models/Bot');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+// Get all bots for the authenticated user
+router.get('/', auth, async (req, res) => {
+  const bots = await Bot.find({ owner: req.user._id });
+  res.json(bots);
+});
+
+// Create new bot
+router.post('/', auth, async (req, res) => {
+  try {
+    const bot = await Bot.create({ ...req.body, owner: req.user._id });
+    res.status(201).json(bot);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: 'Failed to create bot' });
+  }
+});
+
+// Get a single bot
+router.get('/:id', auth, async (req, res) => {
+  const bot = await Bot.findOne({ _id: req.params.id, owner: req.user._id });
+  if (!bot) return res.status(404).json({ message: 'Bot not found' });
+  res.json(bot);
+});
+
+// Update a bot
+router.put('/:id', auth, async (req, res) => {
+  try {
+    const bot = await Bot.findOneAndUpdate(
+      { _id: req.params.id, owner: req.user._id },
+      req.body,
+      { new: true }
+    );
+    if (!bot) return res.status(404).json({ message: 'Bot not found' });
+    res.json(bot);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: 'Failed to update bot' });
+  }
+});
+
+// Delete a bot
+router.delete('/:id', auth, async (req, res) => {
+  const bot = await Bot.findOneAndDelete({ _id: req.params.id, owner: req.user._id });
+  if (!bot) return res.status(404).json({ message: 'Bot not found' });
+  res.json({ success: true });
+});
+
+module.exports = router;

--- a/zaphchat-frontend/App.tsx
+++ b/zaphchat-frontend/App.tsx
@@ -22,7 +22,6 @@ const navigationConfig: NavItemConfig[] = [
 ];
 
 const LG_BREAKPOINT = '(min-width: 1024px)';
-export type ServerStatusType = 'operational' | 'rebooting' | 'down';
 
 const App: React.FC = () => {
   const { token, logout } = useAuth();
@@ -31,30 +30,19 @@ const App: React.FC = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(window.matchMedia(LG_BREAKPOINT).matches);
   const [activePageId, setActivePageId] = useState<string>(navigationConfig[0].id);
   const [pageTitle, setPageTitle] = useState<string>(navigationConfig[0].name);
-  const [serverStatus, setServerStatus] = useState<ServerStatusType>('operational');
-
   useEffect(() => {
     const mediaQuery = window.matchMedia(LG_BREAKPOINT);
-    
+
     const handleMediaQueryChange = (event: MediaQueryListEvent) => {
       setIsSidebarOpen(event.matches);
     };
-  
+
     mediaQuery.addEventListener('change', handleMediaQueryChange);
-  
-    // Mock server status cycling
-    const statuses: ServerStatusType[] = ['operational', 'rebooting', 'down'];
-    let currentStatusIndex = 0;
-    const statusInterval = setInterval(() => {
-      currentStatusIndex = (currentStatusIndex + 1) % statuses.length;
-      setServerStatus(statuses[currentStatusIndex]);
-    }, 15000); // Change status every 15 seconds for demo
 
     return () => {
       mediaQuery.removeEventListener('change', handleMediaQueryChange);
-      clearInterval(statusInterval);
     };
-  }, []); 
+  }, []);
   
 
   const toggleSidebar = () => {
@@ -105,7 +93,6 @@ const App: React.FC = () => {
         pageTitle={pageTitle}
         isSidebarOpen={isSidebarOpen}
         toggleSidebar={toggleSidebar}
-        serverStatus={serverStatus}
         onLogout={logout}
       />
       <div className="flex flex-1 overflow-hidden relative"> {/* Added relative for absolute positioning of Sidebar */}

--- a/zaphchat-frontend/api.ts
+++ b/zaphchat-frontend/api.ts
@@ -14,12 +14,14 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
 }
 
 export const api = {
-  getStats: () => apiFetch('/stats'),
-  getMessagesToday: () => apiFetch<{count: number}>('/messages/today'),
-  getActiveUsers: () => apiFetch<{count: number}>('/users/active'),
-  getActivity: () => apiFetch<any[]>('/activity'),
+  ping: () => apiFetch('/ping'),
+  getServerStatus: () => apiFetch('/status'),
   getBots: () => apiFetch<any[]>('/bots'),
-  getUsers: () => apiFetch<any[]>('/users'),
-  getLogs: () => apiFetch<any[]>('/logs'),
-  getTasks: () => apiFetch<any[]>('/tasks'),
+  createBot: (data: any) => apiFetch('/bots', { method: 'POST', body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } }),
+  updateBot: (id: string, data: any) => apiFetch(`/bots/${id}`, { method: 'PUT', body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } }),
+  deleteBot: (id: string) => apiFetch(`/bots/${id}`, { method: 'DELETE' }),
+  getMessageStats: () => apiFetch<{ count: number }>('/stats/messages'),
+  getActiveUsers: () => apiFetch<{ count: number }>('/stats/active-users'),
+  getRecentActivity: () => apiFetch<any[]>('/activity/recent'),
+  getSchedulerTasks: () => apiFetch<any[]>('/scheduler/tasks'),
 };

--- a/zaphchat-frontend/components/AccountSettings.tsx
+++ b/zaphchat-frontend/components/AccountSettings.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import PremiumButton from './PremiumButton';
+import GlassCard from './GlassCard';
+import { useAuth } from '../AuthContext';
+import { api, apiFetch } from '../api';
+
+interface Props { onClose: () => void; }
+
+const AccountSettings: React.FC<Props> = ({ onClose }) => {
+  const { user } = useAuth();
+  const [name, setName] = useState(user?.displayName || '');
+  const [email, setEmail] = useState(user?.email || '');
+  const [phone, setPhone] = useState(user?.phone || '');
+  const [website, setWebsite] = useState(user?.website || '');
+  const [password, setPassword] = useState('');
+  const [oldPassword, setOldPassword] = useState('');
+
+  const save = async () => {
+    try {
+      await apiFetch('/users/me', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, phone, website, password, oldPassword }),
+      });
+      onClose();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <GlassCard className="w-full max-w-md">
+        <h2 className="text-xl font-semibold text-slate-100 mb-4">Account Settings</h2>
+        <div className="space-y-3">
+          <input className="w-full bg-slate-700/60 px-3 py-2 rounded" value={name} onChange={e=>setName(e.target.value)} placeholder="Name" />
+          <input className="w-full bg-slate-700/60 px-3 py-2 rounded" value={email} onChange={e=>setEmail(e.target.value)} placeholder="Email" />
+          <input className="w-full bg-slate-700/60 px-3 py-2 rounded" value={phone} onChange={e=>setPhone(e.target.value)} placeholder="Phone" />
+          <input className="w-full bg-slate-700/60 px-3 py-2 rounded" value={website} onChange={e=>setWebsite(e.target.value)} placeholder="Website" />
+          <input className="w-full bg-slate-700/60 px-3 py-2 rounded" type="password" value={oldPassword} onChange={e=>setOldPassword(e.target.value)} placeholder="Old Password" />
+          <input className="w-full bg-slate-700/60 px-3 py-2 rounded" type="password" value={password} onChange={e=>setPassword(e.target.value)} placeholder="New Password" />
+        </div>
+        <div className="mt-4 flex justify-end space-x-2">
+          <PremiumButton variant="secondary" onClick={onClose}>Cancel</PremiumButton>
+          <PremiumButton onClick={save}>Save</PremiumButton>
+        </div>
+      </GlassCard>
+    </div>
+  );
+};
+
+export default AccountSettings;

--- a/zaphchat-frontend/components/BotManager.tsx
+++ b/zaphchat-frontend/components/BotManager.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import GlassCard from './GlassCard';
+import PremiumButton from './PremiumButton';
+import { api } from '../api';
+import { Bot } from '../types';
+import { EditIcon, TrashIcon } from './icons';
+
+interface Props { onClose: () => void; }
+
+const BotManager: React.FC<Props> = ({ onClose }) => {
+  const [bots, setBots] = useState<Bot[]>([]);
+  const [editing, setEditing] = useState<Bot | null>(null);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = async () => {
+    const b = await api.getBots();
+    setBots(b);
+  };
+
+  const save = async () => {
+    if (!editing) return;
+    if (editing._id) await api.updateBot(editing._id, editing);
+    else await api.createBot(editing);
+    setEditing(null);
+    load();
+  };
+
+  const remove = async (id: string) => {
+    await api.deleteBot(id);
+    load();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 overflow-auto p-4">
+      <GlassCard className="w-full max-w-2xl">
+        <h2 className="text-xl font-semibold text-slate-100 mb-4">Manage Bots</h2>
+        {editing ? (
+          <div className="space-y-2">
+            <input className="w-full bg-slate-700/60 px-2 py-1 rounded" value={editing.botName} onChange={e=>setEditing({ ...editing, botName: e.target.value })} placeholder="Bot Name" />
+            <input className="w-full bg-slate-700/60 px-2 py-1 rounded" value={editing.phoneNumber} onChange={e=>setEditing({ ...editing, phoneNumber: e.target.value })} placeholder="Phone" />
+            <input className="w-full bg-slate-700/60 px-2 py-1 rounded" value={editing.whatsappId} onChange={e=>setEditing({ ...editing, whatsappId: e.target.value })} placeholder="WhatsApp ID" />
+            <textarea className="w-full bg-slate-700/60 px-2 py-1 rounded" rows={3} value={editing.personality} onChange={e=>setEditing({ ...editing, personality: e.target.value })} placeholder="Personality" />
+            <select className="w-full bg-slate-700/60 px-2 py-1 rounded" value={editing.status} onChange={e=>setEditing({ ...editing, status: e.target.value as any })}>
+              <option value="online">Online</option>
+              <option value="paused">Paused</option>
+              <option value="archived">Archived</option>
+            </select>
+            <div className="flex justify-end space-x-2 pt-2">
+              <PremiumButton variant="secondary" onClick={()=>setEditing(null)}>Cancel</PremiumButton>
+              <PremiumButton onClick={save}>Save</PremiumButton>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2 max-h-60 overflow-y-auto">
+              {bots.map(b => (
+                <div key={b._id} className="flex items-center justify-between bg-slate-700/50 px-3 py-2 rounded">
+                  <span className="text-slate-100">{b.botName}</span>
+                  <div className="space-x-2">
+                    <button onClick={()=>setEditing(b)}><EditIcon className="w-5 h-5" /></button>
+                    <button onClick={()=>b._id && remove(b._id)}><TrashIcon className="w-5 h-5" /></button>
+                  </div>
+                </div>
+              ))}
+              {bots.length === 0 && <p className="text-slate-400">No bots yet.</p>}
+            </div>
+            <div className="pt-4 flex justify-between">
+              <PremiumButton variant="secondary" onClick={onClose}>Close</PremiumButton>
+              <PremiumButton onClick={()=>setEditing({ botName:'', phoneNumber:'', whatsappId:'', status:'online', personality:'', contacts:[], conversations:[], messages:[] })}>Add Bot</PremiumButton>
+            </div>
+          </>
+        )}
+      </GlassCard>
+    </div>
+  );
+};
+
+export default BotManager;

--- a/zaphchat-frontend/components/BroadcastModal.tsx
+++ b/zaphchat-frontend/components/BroadcastModal.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import GlassCard from './GlassCard';
+import PremiumButton from './PremiumButton';
+import { api, apiFetch } from '../api';
+import { Bot } from '../types';
+
+interface Props { onClose: () => void; }
+
+const BroadcastModal: React.FC<Props> = ({ onClose }) => {
+  const [bots, setBots] = useState<Bot[]>([]);
+  const [botId, setBotId] = useState('');
+  const [message, setMessage] = useState('');
+  const [schedule, setSchedule] = useState('');
+
+  useEffect(() => { api.getBots().then(setBots); }, []);
+
+  const send = async () => {
+    await apiFetch('/broadcast', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ botId, message, schedule }),
+    });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <GlassCard className="w-full max-w-md">
+        <h2 className="text-xl font-semibold text-slate-100 mb-4">New Broadcast</h2>
+        <select className="w-full bg-slate-700/60 px-2 py-1 rounded mb-2" value={botId} onChange={e=>setBotId(e.target.value)}>
+          <option value="">Select Bot</option>
+          {bots.map(b=> <option key={b._id} value={b._id}>{b.botName}</option>)}
+        </select>
+        <textarea className="w-full bg-slate-700/60 px-2 py-1 rounded mb-2" rows={3} value={message} onChange={e=>setMessage(e.target.value)} placeholder="Message" />
+        <input className="w-full bg-slate-700/60 px-2 py-1 rounded mb-2" type="datetime-local" value={schedule} onChange={e=>setSchedule(e.target.value)} />
+        <div className="flex justify-end space-x-2">
+          <PremiumButton variant="secondary" onClick={onClose}>Cancel</PremiumButton>
+          <PremiumButton onClick={send}>Send</PremiumButton>
+        </div>
+      </GlassCard>
+    </div>
+  );
+};
+
+export default BroadcastModal;

--- a/zaphchat-frontend/components/Header.tsx
+++ b/zaphchat-frontend/components/Header.tsx
@@ -1,38 +1,21 @@
 
-import React from 'react';
-import { MenuIcon, XIcon, BellIcon, ChevronDownIcon, ServerIcon } from './icons'; 
-import { ServerStatusType } from '../../App'; // Import ServerStatusType
+import React, { useState } from 'react';
+import { MenuIcon, XIcon, BellIcon, ChevronDownIcon } from './icons';
+import ServerStatusIcon from './ServerStatusIcon';
+import AccountSettings from './AccountSettings';
+import { useAuth } from '../AuthContext';
 
 interface HeaderProps {
   appName: string;
   pageTitle: string;
   isSidebarOpen: boolean;
   toggleSidebar: () => void;
-  serverStatus: ServerStatusType; // Added serverStatus prop
   onLogout: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ appName, pageTitle, isSidebarOpen, toggleSidebar, serverStatus, onLogout }) => {
-  
-  const getServerStatusIndicator = () => {
-    let iconColor = 'text-slate-500'; // Default
-    let pulseClass = '';
-
-    switch (serverStatus) {
-      case 'operational':
-        iconColor = 'text-green-500';
-        break;
-      case 'rebooting':
-        iconColor = 'text-yellow-500';
-        pulseClass = 'animate-pulse';
-        break;
-      case 'down':
-        iconColor = 'text-red-500';
-        pulseClass = 'animate-pulse';
-        break;
-    }
-    return <ServerIcon className={`w-5 h-5 mr-2 ${iconColor} ${pulseClass}`} title={`Server Status: ${serverStatus}`} />;
-  };
+const Header: React.FC<HeaderProps> = ({ appName, pageTitle, isSidebarOpen, toggleSidebar, onLogout }) => {
+  const { user } = useAuth();
+  const [showAccount, setShowAccount] = useState(false);
 
   return (
     <header className="sticky top-0 z-30 flex items-center justify-between h-20 px-4 md:px-8 bg-slate-900/70 backdrop-blur-xl border-b border-slate-700/50 shadow-lg">
@@ -46,7 +29,7 @@ const Header: React.FC<HeaderProps> = ({ appName, pageTitle, isSidebarOpen, togg
           {isSidebarOpen ? <XIcon className="w-7 h-7" /> : <MenuIcon className="w-7 h-7" />}
         </button>
         <div className="flex items-center">
-          {getServerStatusIndicator()} {/* Server Status Icon */}
+          <ServerStatusIcon />
            <img src="https://picsum.photos/seed/zaphlogo/32/32" alt="ZaphChat Logo" className="h-8 w-8 rounded-md mr-3 hidden sm:block" />
           <span className="text-2xl font-bold text-slate-100 tracking-tight hidden md:block">{appName}</span>
         </div>
@@ -72,25 +55,17 @@ const Header: React.FC<HeaderProps> = ({ appName, pageTitle, isSidebarOpen, togg
           {/* <span className="absolute top-0 right-0 block h-2 w-2 rounded-full bg-red-500 ring-2 ring-slate-800" /> */}
         </button>
 
-        {/* User Profile Dropdown Placeholder */}
         <div className="relative">
-          <button className="flex items-center space-x-2 p-1 pr-2 rounded-full hover:bg-slate-700/50 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 focus:ring-cyan-500">
+          <button onClick={() => setShowAccount(true)} className="flex items-center space-x-2 p-1 pr-2 rounded-full hover:bg-slate-700/50 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 focus:ring-cyan-500">
             <img
-              className="h-9 w-9 rounded-full border-2 border-slate-600 group-hover:border-cyan-500/70"
-              src="https://picsum.photos/seed/user/100/100" // Replace with actual user avatar
+              className="h-9 w-9 rounded-full border-2 border-slate-600"
+              src="https://picsum.photos/seed/user/100/100"
               alt="User Avatar"
             />
-            <span className="text-sm font-medium text-slate-200 hidden lg:block">Jane Doe</span>
+            <span className="text-sm font-medium text-slate-200 hidden lg:block">{user?.displayName}</span>
             <ChevronDownIcon className="w-4 h-4 text-slate-400 hidden lg:block" />
           </button>
-          {/* Dropdown menu (absolute positioned, hidden by default) */}
-          {/* 
-          <div className="absolute right-0 mt-2 w-48 bg-slate-800/80 backdrop-blur-md rounded-xl shadow-xl border border-slate-700/70 py-1 hidden">
-            <a href="#" className="block px-4 py-2 text-sm text-slate-300 hover:bg-slate-700/60 hover:text-slate-100">Your Profile</a>
-            <a href="#" className="block px-4 py-2 text-sm text-slate-300 hover:bg-slate-700/60 hover:text-slate-100">Settings</a>
-            <a href="#" className="block px-4 py-2 text-sm text-slate-300 hover:bg-slate-700/60 hover:text-slate-100">Sign out</a>
-          </div> 
-          */}
+          {showAccount && <AccountSettings onClose={() => setShowAccount(false)} />}
         </div>
         <button
           onClick={onLogout}

--- a/zaphchat-frontend/components/ServerStatusIcon.tsx
+++ b/zaphchat-frontend/components/ServerStatusIcon.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { ServerIcon } from './icons';
+import { api } from '../api';
+
+const STATUS_COLORS: Record<string, string> = {
+  online: 'text-green-500 animate-pulse',
+  offline: 'text-red-500',
+  rebooting: 'text-yellow-500 animate-pulse',
+};
+
+const ServerStatusIcon: React.FC = () => {
+  const [status, setStatus] = useState<'online' | 'offline' | 'rebooting'>('online');
+
+  useEffect(() => {
+    let mounted = true;
+    async function ping() {
+      try {
+        await api.ping();
+        if (mounted) setStatus('online');
+      } catch {
+        if (mounted) setStatus('offline');
+      }
+    }
+    ping();
+    const id = setInterval(ping, 10000);
+    return () => {
+      mounted = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  return <ServerIcon className={`w-5 h-5 ${STATUS_COLORS[status]}`} />;
+};
+
+export default ServerStatusIcon;

--- a/zaphchat-frontend/components/pages/DashboardPage.tsx
+++ b/zaphchat-frontend/components/pages/DashboardPage.tsx
@@ -5,6 +5,8 @@ import GlassCard from '../GlassCard';
 import PremiumButton from '../PremiumButton';
 import { PageProps, Layouts, Layout } from '../../types';
 import { MessageSquareIcon, UsersIcon, SettingsIcon, CheckCircleIcon, AlertTriangleIcon, ClockIcon, ChevronDownIcon, ChevronUpIcon, RobotIcon } from '../icons'; // Removed ServerIcon as it's no longer used here
+import BotManager from '../BotManager';
+import BroadcastModal from '../BroadcastModal';
 import WeatherDateTimeWidget from '../WeatherDateTimeWidget'; 
 // Conceptually import react-grid-layout. In a real project: npm install react-grid-layout @types/react-grid-layout
 import { Responsive, WidthProvider } from 'react-grid-layout';
@@ -102,6 +104,8 @@ const DashboardPage: React.FC<PageProps> = () => {
   const [scheduledTaskCount, setScheduledTaskCount] = useState<number | null>(null);
   const [recentActivity, setRecentActivity] = useState<any[]>([]);
   const [deployedBots, setDeployedBots] = useState<any[]>([]);
+  const [showBotManager, setShowBotManager] = useState(false);
+  const [showBroadcast, setShowBroadcast] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -132,10 +136,10 @@ const DashboardPage: React.FC<PageProps> = () => {
     async function load() {
       try {
         const [msg, users, tasks, activity, bots] = await Promise.all([
-          api.getMessagesToday().catch(() => ({ count: 0 })),
+          api.getMessageStats().catch(() => ({ count: 0 })),
           api.getActiveUsers().catch(() => ({ count: 0 })),
-          api.getTasks().catch(() => []),
-          api.getActivity().catch(() => []),
+          api.getSchedulerTasks().catch(() => []),
+          api.getRecentActivity().catch(() => []),
           api.getBots().catch(() => []),
         ]);
         setMessageVolume(msg.count);
@@ -265,7 +269,7 @@ const DashboardPage: React.FC<PageProps> = () => {
                 ))}
                 {deployedBots.length === 0 && <p className="text-slate-400 text-center py-4">No bots deployed yet.</p>}
             </div>
-            <PremiumButton variant="secondary" className="w-full mt-4 !text-sm">Manage All Bots</PremiumButton>
+            <PremiumButton variant="secondary" className="w-full mt-4 !text-sm" onClick={() => setShowBotManager(true)}>Manage All Bots</PremiumButton>
         </GlassCard>
       </div>
       
@@ -275,19 +279,22 @@ const DashboardPage: React.FC<PageProps> = () => {
               <p className="text-slate-300 mb-4">Manage your bot settings or start a new interaction.</p>
             </div>
             <div className="space-y-3 mt-auto">
-                <PremiumButton 
+                <PremiumButton
+                    onClick={() => setShowBotManager(true)}
                     icon={<SettingsIcon className="w-5 h-5 mr-2"/>}
                     className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 focus:ring-purple-500/50 hover:shadow-[0_0_20px_0px_rgba(168,85,247,0.5)]"
                 >
                     Manage Bot
                 </PremiumButton>
-                 <PremiumButton variant="secondary" className="w-full">
+                <PremiumButton variant="secondary" className="w-full" onClick={() => setShowBroadcast(true)}>
                     New Broadcast
                 </PremiumButton>
             </div>
         </GlassCard>
       </div>
     </ResponsiveGridLayout>
+    {showBotManager && <BotManager onClose={() => setShowBotManager(false)} />}
+    {showBroadcast && <BroadcastModal onClose={() => setShowBroadcast(false)} />}
   );
 };
 

--- a/zaphchat-frontend/types.ts
+++ b/zaphchat-frontend/types.ts
@@ -41,3 +41,15 @@ export interface WeatherData {
   sunset?: number; // timestamp
   error?: string;
 }
+
+export interface Bot {
+  _id?: string;
+  botName: string;
+  phoneNumber: string;
+  whatsappId: string;
+  status: 'online' | 'paused' | 'archived';
+  personality: string;
+  contacts: { name: string; phoneNumber: string }[];
+  conversations: any[];
+  messages: any[];
+}


### PR DESCRIPTION
## Summary
- add mongoose `Bot` model
- implement authenticated CRUD API routes for bots
- expose stats and scheduler endpoints
- show real server status and account settings in header
- add bot management and broadcast modals on dashboard
- wire up new API functions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc3b78e0832084bcecb1f5e80428