### PR TITLE
Improve dashboard modals and layout

### DIFF
--- a/zaphchat-frontend/App.tsx
+++ b/zaphchat-frontend/App.tsx
@@ -54,7 +54,7 @@ const App: React.FC = () => {
     if (selectedNavItem) {
       setActivePageId(selectedNavItem.id);
       setPageTitle(selectedNavItem.name);
-      if (isSidebarOpen && !window.matchMedia(LG_BREAKPOINT).matches) { // Close only if manually opened on small screens
+      if (!window.matchMedia(LG_BREAKPOINT).matches) {
         setIsSidebarOpen(false);
       }
     }

--- a/zaphchat-frontend/components/AccountSettings.tsx
+++ b/zaphchat-frontend/components/AccountSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PremiumButton from './PremiumButton';
 import GlassCard from './GlassCard';
+import Modal from './Modal';
 import { useAuth } from '../AuthContext';
 import { api, apiFetch } from '../api';
 
@@ -29,8 +30,8 @@ const AccountSettings: React.FC<Props> = ({ onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <GlassCard className="w-full max-w-md">
+    <Modal onClose={onClose} containerClassName="w-full max-w-md">
+      <GlassCard className="w-full">
         <h2 className="text-xl font-semibold text-slate-100 mb-4">Account Settings</h2>
         <div className="space-y-3">
           <input className="w-full bg-slate-700/60 px-3 py-2 rounded" value={name} onChange={e=>setName(e.target.value)} placeholder="Name" />
@@ -45,7 +46,7 @@ const AccountSettings: React.FC<Props> = ({ onClose }) => {
           <PremiumButton onClick={save}>Save</PremiumButton>
         </div>
       </GlassCard>
-    </div>
+    </Modal>
   );
 };
 

--- a/zaphchat-frontend/components/BotManager.tsx
+++ b/zaphchat-frontend/components/BotManager.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import GlassCard from './GlassCard';
 import PremiumButton from './PremiumButton';
+import Modal from './Modal';
 import { api } from '../api';
 import { Bot } from '../types';
 import { EditIcon, TrashIcon } from './icons';
@@ -34,8 +35,8 @@ const BotManager: React.FC<Props> = ({ onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 overflow-auto p-4">
-      <GlassCard className="w-full max-w-2xl">
+    <Modal onClose={onClose} containerClassName="w-full max-w-2xl overflow-auto">
+      <GlassCard className="w-full">
         <h2 className="text-xl font-semibold text-slate-100 mb-4">Manage Bots</h2>
         {editing ? (
           <div className="space-y-2">
@@ -74,7 +75,7 @@ const BotManager: React.FC<Props> = ({ onClose }) => {
           </>
         )}
       </GlassCard>
-    </div>
+    </Modal>
   );
 };
 

--- a/zaphchat-frontend/components/BroadcastModal.tsx
+++ b/zaphchat-frontend/components/BroadcastModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import GlassCard from './GlassCard';
 import PremiumButton from './PremiumButton';
+import Modal from './Modal';
 import { api, apiFetch } from '../api';
 import { Bot } from '../types';
 
@@ -24,8 +25,8 @@ const BroadcastModal: React.FC<Props> = ({ onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <GlassCard className="w-full max-w-md">
+    <Modal onClose={onClose} containerClassName="w-full max-w-md">
+      <GlassCard className="w-full">
         <h2 className="text-xl font-semibold text-slate-100 mb-4">New Broadcast</h2>
         <select className="w-full bg-slate-700/60 px-2 py-1 rounded mb-2" value={botId} onChange={e=>setBotId(e.target.value)}>
           <option value="">Select Bot</option>
@@ -38,7 +39,7 @@ const BroadcastModal: React.FC<Props> = ({ onClose }) => {
           <PremiumButton onClick={send}>Send</PremiumButton>
         </div>
       </GlassCard>
-    </div>
+    </Modal>
   );
 };
 

--- a/zaphchat-frontend/components/Modal.tsx
+++ b/zaphchat-frontend/components/Modal.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+
+interface ModalProps {
+  onClose: () => void;
+  children: React.ReactNode;
+  containerClassName?: string;
+}
+
+const Modal: React.FC<ModalProps> = ({ onClose, children, containerClassName = '' }) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true));
+  }, []);
+
+  const close = () => {
+    setVisible(false);
+    setTimeout(onClose, 300);
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 bg-black/50 flex items-start md:items-center justify-center overflow-y-auto py-8 z-50 transition-opacity duration-300 ${visible ? 'opacity-100' : 'opacity-0'}`}
+      onClick={close}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        className={`transform transition-transform duration-300 ${visible ? 'translate-y-0' : '-translate-y-4'} ${containerClassName}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/zaphchat-frontend/components/pages/DashboardPage.tsx
+++ b/zaphchat-frontend/components/pages/DashboardPage.tsx
@@ -173,8 +173,9 @@ const DashboardPage: React.FC<PageProps> = () => {
       layouts={layouts}
       breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
       cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}
-      rowHeight={80} 
+      rowHeight={80}
       onLayoutChange={onLayoutChange}
+      draggableCancel=".no-drag"
       // isDraggable is now controlled per item in the layout definition
     >
       <div key="welcome">
@@ -262,7 +263,7 @@ const DashboardPage: React.FC<PageProps> = () => {
                         <div className="flex items-center">
                             <RobotIcon className="w-7 h-7 mr-3 text-cyan-400 flex-shrink-0" />
                             <div>
-                                <p className="text-slate-100 font-medium">{bot.name}</p>
+                                <p className="text-slate-100 font-medium">{bot.botName}</p>
                             </div>
                         </div>
                         <DeployedBotStatusIndicator status={bot.status} />
@@ -270,7 +271,7 @@ const DashboardPage: React.FC<PageProps> = () => {
                 ))}
                 {deployedBots.length === 0 && <p className="text-slate-400 text-center py-4">No bots deployed yet.</p>}
             </div>
-            <PremiumButton variant="secondary" className="w-full mt-4 !text-sm" onClick={() => setShowBotManager(true)}>Manage All Bots</PremiumButton>
+            <PremiumButton variant="secondary" className="no-drag w-full mt-4 !text-sm" onClick={() => setShowBotManager(true)}>Manage All Bots</PremiumButton>
         </GlassCard>
       </div>
       
@@ -279,15 +280,15 @@ const DashboardPage: React.FC<PageProps> = () => {
             <div className="flex-grow">
               <p className="text-slate-300 mb-4">Manage your bot settings or start a new interaction.</p>
             </div>
-            <div className="space-y-3 mt-auto">
+            <div className="flex flex-wrap gap-3 mt-auto">
                 <PremiumButton
                     onClick={() => setShowBotManager(true)}
                     icon={<SettingsIcon className="w-5 h-5 mr-2"/>}
-                    className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 focus:ring-purple-500/50 hover:shadow-[0_0_20px_0px_rgba(168,85,247,0.5)]"
+                    className="no-drag flex-1 min-w-[8rem] bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 focus:ring-purple-500/50 hover:shadow-[0_0_20px_0px_rgba(168,85,247,0.5)]"
                 >
                     Manage Bot
                 </PremiumButton>
-                <PremiumButton variant="secondary" className="w-full" onClick={() => setShowBroadcast(true)}>
+                <PremiumButton variant="secondary" className="no-drag flex-1 min-w-[8rem]" onClick={() => setShowBroadcast(true)}>
                     New Broadcast
                 </PremiumButton>
             </div>


### PR DESCRIPTION
## Summary
- create Modal component for fade & slide effects
- use Modal in account, bot manager and broadcast modals
- make sidebar auto close on navigation
- fix deployed bot name field
- improve quick actions layout and button interaction
- prevent grid dragging from swallowing button clicks

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68460bd9e268832087b70389ae0e1d79