### PR TITLE
Fix auth persistence in ZaphChat frontend

### DIFF
--- a/zaphchat-frontend/App.tsx
+++ b/zaphchat-frontend/App.tsx
@@ -24,7 +24,7 @@ const navigationConfig: NavItemConfig[] = [
 const LG_BREAKPOINT = '(min-width: 1024px)';
 
 const App: React.FC = () => {
-  const { token, logout } = useAuth();
+  const { token, logout, loading } = useAuth();
   const { addToast } = useToast();
   const [showRegister, setShowRegister] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(window.matchMedia(LG_BREAKPOINT).matches);
@@ -67,6 +67,10 @@ const App: React.FC = () => {
       setPageTitle(navigationConfig[0].name);
     }
   }, [activePageId]);
+
+  if (loading) {
+    return null;
+  }
 
   if (!token) {
     if (showRegister) {


### PR DESCRIPTION
## Summary
- persist token on login
- check stored token on startup and fetch user
- gracefully logout on invalid session
- expose auth loading state and block render until ready
- handle loading state in App

## Testing
- `npm --prefix zaphchat-frontend run build` *(fails: vite not found)*
- `npx tsc -p zaphchat-frontend/tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68461f98c88c832090ecd3abe3cb8703