### PR TITLE
Fix DashboardPage TypeScript types

### DIFF
--- a/zaphchat-frontend/api.ts
+++ b/zaphchat-frontend/api.ts
@@ -1,3 +1,12 @@
+import {
+  Bot,
+  MessageStatsResponse,
+  ActiveUsersResponse,
+  ServerStatusResponse,
+  ActivityItem,
+  ScheduledTask,
+} from './types';
+
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
 
 export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
@@ -14,17 +23,17 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
 }
 
 export const api = {
-  ping: () => apiFetch('/ping'),
-  getServerStatus: () => apiFetch('/status'),
+  ping: () => apiFetch<{ status: string }>('/ping'),
+  getServerStatus: () => apiFetch<ServerStatusResponse>('/status'),
   startBot: () => apiFetch('/bot/start', { method: 'POST' }),
   stopBot: () => apiFetch('/bot/stop', { method: 'POST' }),
   restartBot: () => apiFetch('/bot/restart', { method: 'POST' }),
-  getBots: () => apiFetch<any[]>('/bots'),
+  getBots: () => apiFetch<Bot[]>('/bots'),
   createBot: (data: any) => apiFetch('/bots', { method: 'POST', body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } }),
   updateBot: (id: string, data: any) => apiFetch(`/bots/${id}`, { method: 'PUT', body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } }),
   deleteBot: (id: string) => apiFetch(`/bots/${id}`, { method: 'DELETE' }),
-  getMessageStats: () => apiFetch<{ count: number }>('/stats/messages'),
-  getActiveUsers: () => apiFetch<{ count: number }>('/stats/active-users'),
-  getRecentActivity: () => apiFetch<any[]>('/activity/recent'),
-  getSchedulerTasks: () => apiFetch<any[]>('/scheduler/tasks'),
+  getMessageStats: () => apiFetch<MessageStatsResponse>('/stats/messages'),
+  getActiveUsers: () => apiFetch<ActiveUsersResponse>('/stats/active-users'),
+  getRecentActivity: () => apiFetch<ActivityItem[]>('/activity/recent'),
+  getSchedulerTasks: () => apiFetch<ScheduledTask[]>('/scheduler/tasks'),
 };

--- a/zaphchat-frontend/components/pages/DashboardPage.tsx
+++ b/zaphchat-frontend/components/pages/DashboardPage.tsx
@@ -3,7 +3,17 @@ import React, { useState, useEffect } from 'react';
 import { api } from '../../api';
 import GlassCard from '../GlassCard';
 import PremiumButton from '../PremiumButton';
-import { PageProps, Layouts, Layout } from '../../types';
+import {
+  PageProps,
+  Layouts,
+  Layout,
+  ActivityItem,
+  Bot,
+  MessageStatsResponse,
+  ActiveUsersResponse,
+  ScheduledTask,
+  ServerStatusResponse,
+} from '../../types';
 import { MessageSquareIcon, UsersIcon, SettingsIcon, CheckCircleIcon, AlertTriangleIcon, ClockIcon, ChevronDownIcon, ChevronUpIcon, RobotIcon } from '../icons'; // Removed ServerIcon as it's no longer used here
 import BotManager from '../BotManager';
 import BroadcastModal from '../BroadcastModal';
@@ -109,8 +119,8 @@ const DashboardPage: React.FC<PageProps> = () => {
   const [messageVolume, setMessageVolume] = useState<number | null>(null);
   const [activeUserCount, setActiveUserCount] = useState<number | null>(null);
   const [scheduledTaskCount, setScheduledTaskCount] = useState<number | null>(null);
-  const [recentActivity, setRecentActivity] = useState<any[]>([]);
-  const [deployedBots, setDeployedBots] = useState<any[]>([]);
+  const [recentActivity, setRecentActivity] = useState<ActivityItem[]>([]);
+  const [deployedBots, setDeployedBots] = useState<Bot[]>([]);
   const [pm2Status, setPm2Status] = useState<string>('unknown');
   const [showBotManager, setShowBotManager] = useState(false);
   const [showBroadcast, setShowBroadcast] = useState(false);
@@ -127,7 +137,7 @@ const DashboardPage: React.FC<PageProps> = () => {
     setShowBroadcast(true);
   };
 
-  const onLayoutChange = (currentLayout: Layout[], allLayouts: Layouts) => {
+  const onLayoutChange = (_layout: Layout[], allLayouts: Layouts) => {
     // Before saving, ensure isResizable is correctly set from initialLayouts definition
     // This is important if react-grid-layout tries to infer it.
     const layoutsToSave: Layouts = {};
@@ -153,7 +163,14 @@ const DashboardPage: React.FC<PageProps> = () => {
   useEffect(() => {
     async function load() {
       try {
-        const [msg, users, tasks, activity, bots, status] = await Promise.all([
+        const [msg, users, tasks, activity, bots, status]: [
+          MessageStatsResponse,
+          ActiveUsersResponse,
+          ScheduledTask[],
+          ActivityItem[],
+          Bot[],
+          ServerStatusResponse,
+        ] = await Promise.all([
           api.getMessageStats().catch(() => ({ count: 0 })),
           api.getActiveUsers().catch(() => ({ count: 0 })),
           api.getSchedulerTasks().catch(() => []),
@@ -163,7 +180,7 @@ const DashboardPage: React.FC<PageProps> = () => {
         ]);
         setMessageVolume(msg.count);
         setActiveUserCount(users.count);
-        setScheduledTaskCount(Array.isArray(tasks) ? tasks.length : tasks.count);
+        setScheduledTaskCount(tasks.length);
         setRecentActivity(activity);
         setDeployedBots(bots);
         setPm2Status(status.status);
@@ -296,11 +313,11 @@ const DashboardPage: React.FC<PageProps> = () => {
         <GlassCard title="Deployed Bots" className="h-full flex flex-col">
             <div className="flex-grow overflow-y-auto space-y-3">
                 {deployedBots.map(bot => (
-                    <div key={bot._id || bot.id} className="flex items-center justify-between p-3 bg-slate-700/40 rounded-xl hover:bg-slate-700/60">
+                    <div key={bot._id} className="flex items-center justify-between p-3 bg-slate-700/40 rounded-xl hover:bg-slate-700/60">
                         <div className="flex items-center min-w-0">
                             <RobotIcon className="w-7 h-7 mr-3 text-cyan-400 flex-shrink-0" />
                             <div className="min-w-0">
-                                <p className="text-slate-100 font-medium truncate">{bot.name || bot.botName}</p>
+                                <p className="text-slate-100 font-medium truncate">{bot.botName}</p>
                             </div>
                         </div>
                         <DeployedBotStatusIndicator status={bot.status} />

--- a/zaphchat-frontend/package.json
+++ b/zaphchat-frontend/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/react-dom": "^19.1.6",
+    "@types/react-grid-layout": "^1.3.5",
     "@types/react-router-dom": "^5.3.3",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"

--- a/zaphchat-frontend/types.ts
+++ b/zaphchat-frontend/types.ts
@@ -53,3 +53,33 @@ export interface Bot {
   conversations: any[];
   messages: any[];
 }
+
+export interface MessageStatsResponse {
+  count: number;
+}
+
+export interface ActiveUsersResponse {
+  count: number;
+}
+
+export interface ServerStatusResponse {
+  status: string;
+}
+
+export interface ActivityItem {
+  user: string;
+  action: string;
+  time: string;
+  status: 'success' | 'error' | 'pending';
+  avatarSeed: string;
+}
+
+export interface ScheduledTask {
+  _id?: string;
+  chatId: string;
+  prompt: string;
+  userId: string;
+  message: string;
+  scheduledTime: string;
+  sent: boolean;
+}


### PR DESCRIPTION
## Summary
- add API response interfaces to types.ts
- use the new interfaces in DashboardPage
- strongly type API helper
- install type packages for React Grid Layout and React DOM
- adjust DeployedBots render logic

## Testing
- `npx tsc -p zaphchat-frontend/tsconfig.json` *(fails: Property 'env' does not exist on type 'ImportMeta', setApiKey unused, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68464e6455b883209ca028b79fac8eb7