### PR TITLE
Fix dashboard CSP and add ErrorBoundary

### DIFF
--- a/zaphchat-frontend/ErrorBoundary.tsx
+++ b/zaphchat-frontend/ErrorBoundary.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<React.PropsWithChildren<{}>, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: unknown) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p className="text-red-500 p-4">Something went wrong.</p>;
+    }
+    return this.props.children;
+  }
+}

--- a/zaphchat-frontend/components/pages/DashboardPage.tsx
+++ b/zaphchat-frontend/components/pages/DashboardPage.tsx
@@ -319,7 +319,10 @@ const DashboardPage: React.FC<PageProps> = () => {
                 <li key={i} className="flex items-center p-3 bg-slate-700/40 rounded-xl hover:bg-slate-700/60 transition-colors duration-200">
                   <img src={`https://picsum.photos/seed/${activity.avatarSeed}/40/40`} alt="User" className="w-10 h-10 rounded-full mr-4 border-2 border-purple-500/60" />
                   <div className="flex-1">
-                    <p className="text-slate-200 font-medium">{activity.user}: <span className="text-slate-300 font-normal">{activity.action}</span></p>
+                    <p className="text-slate-200 font-medium">
+                      {typeof activity.user === 'object' ? (activity.user.displayName || activity.user.email) : activity.user}:
+                      <span className="text-slate-300 font-normal">{activity.action}</span>
+                    </p>
                     <p className="text-xs text-slate-400">{activity.time}</p>
                   </div>
                   {activity.status === 'error' && <AlertTriangleIcon className="w-5 h-5 text-red-500 ml-2" />}

--- a/zaphchat-frontend/index.css
+++ b/zaphchat-frontend/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/zaphchat-frontend/index.html
+++ b/zaphchat-frontend/index.html
@@ -5,13 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy"
         content="default-src 'self';
-                 connect-src 'self' http://localhost:3001;
+                 connect-src 'self' http://localhost:3001 ws://localhost:3001;
                  img-src 'self' data: https://picsum.photos https://fastly.picsum.photos;
                  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
                  font-src https://fonts.gstatic.com;
-                 script-src 'self' 'unsafe-eval' https://cdn.tailwindcss.com https://esm.sh">
+                 script-src 'self' 'unsafe-eval' https://esm.sh">
   <title>ZaphChat Dashboard</title>
-  <script src="https://cdn.tailwindcss.com"></script>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
     html, body, #root {

--- a/zaphchat-frontend/index.tsx
+++ b/zaphchat-frontend/index.tsx
@@ -4,6 +4,7 @@ import App from './App';
 import { AuthProvider } from './AuthContext';
 import { ToastProvider } from './components/ToastProvider';
 import { BrowserRouter } from 'react-router-dom'; // ✅ import this
+import ErrorBoundary from './ErrorBoundary';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -13,10 +14,12 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <BrowserRouter> {/* ✅ wrap everything inside */}
+    <BrowserRouter>
       <ToastProvider>
         <AuthProvider>
-          <App />
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
         </AuthProvider>
       </ToastProvider>
     </BrowserRouter>

--- a/zaphchat-frontend/postcss.config.js
+++ b/zaphchat-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/zaphchat-frontend/tailwind.config.js
+++ b/zaphchat-frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './**/*.{ts,tsx,js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/zaphchat-frontend/types.ts
+++ b/zaphchat-frontend/types.ts
@@ -67,7 +67,7 @@ export interface ServerStatusResponse {
 }
 
 export interface ActivityItem {
-  user: string;
+  user: string | { displayName?: string; email?: string };
   action: string;
   time: string;
   status: 'success' | 'error' | 'pending';


### PR DESCRIPTION
## Summary
- allow WebSocket connections in CSP
- remove Tailwind CDN and prepare local build
- render activity user correctly
- add simple ErrorBoundary wrapper
- configure Tailwind with PostCSS

## Testing
- `npm run build` *(fails: requires `@tailwindcss/postcss`)*

------
https://chatgpt.com/codex/tasks/task_e_6847873203f883209a5c1089db55d20a