### PR TITLE
Fix Tailwind PostCSS plugin location for Vite

### DIFF
--- a/zaphchat-frontend/package.json
+++ b/zaphchat-frontend/package.json
@@ -17,6 +17,7 @@
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.8",
     "@types/node": "^22.14.0",
     "@types/react-dom": "^19.1.6",
     "@types/react-grid-layout": "^1.3.5",

--- a/zaphchat-frontend/postcss.config.js
+++ b/zaphchat-frontend/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- install `@tailwindcss/postcss`
- use new plugin name in PostCSS config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847c80ad7748320b8ade0be6ff5d6e3