### PR TITLE
Fix PostCSS Tailwind plugin

### DIFF
--- a/zaphchat-frontend/package.json
+++ b/zaphchat-frontend/package.json
@@ -17,7 +17,9 @@
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.8",
+    "tailwindcss": "^4.1.8",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.4",
     "@types/node": "^22.14.0",
     "@types/react-dom": "^19.1.6",
     "@types/react-grid-layout": "^1.3.5",

--- a/zaphchat-frontend/postcss.config.js
+++ b/zaphchat-frontend/postcss.config.js
@@ -1,6 +1,6 @@
-export default {
+module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- remove the incorrect `@tailwindcss/postcss` dependency
- add `tailwindcss`, `autoprefixer` and `postcss` as dev dependencies
- configure PostCSS to load Tailwind correctly

## Testing
- `npm install --legacy-peer-deps`
- `npm ls tailwindcss`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68485bcbb82c8320b3c8bca7673a1604